### PR TITLE
Update to latest Zig version

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,54 +1,20 @@
 const std = @import("std");
 
-// Although this function looks imperative, note that its job is to
-// declaratively construct a build graph that will be executed by an external
-// runner.
 pub fn build(b: *std.Build) void {
-    // Standard target options allows the person running `zig build` to choose
-    // what target to build for. Here we do not override the defaults, which
-    // means any target is allowed, and the default is native. Other options
-    // for restricting supported target set are available.
     const target = b.standardTargetOptions(.{});
-
-    // Standard optimization options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
-    // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("zigdeck", .{
-        .root_source_file = b.path("lib.zig" ),
-        .target = target,
-        .optimize = optimize,
-     });
-
-    const lib = b.addStaticLibrary(.{
-        .name = "zigdeck",
-        // In this case the main source file is merely a path, however, in more
-        // complicated build scripts, this could be a generated file.
+    const mod = b.addModule("zigdeck", .{
         .root_source_file = b.path("lib.zig"),
         .target = target,
         .optimize = optimize,
     });
 
-    // This declares intent for the library to be installed into the standard
-    // location when the user invokes the "install" step (the default step when
-    // running `zig build`).
+    const lib = b.addLibrary(.{ .name = "zigdeck", .root_module = mod });
     b.installArtifact(lib);
 
-
-    // Creates a step for unit testing. This only builds the test executable
-    // but does not run it.
-    const lib_unit_tests = b.addTest(.{
-        .root_source_file = b.path("lib.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-
-    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
-
-    // Similar to creating the run step earlier, this exposes a `test` step to
-    // the `zig build --help` menu, providing a way for the user to request
-    // running the unit tests.
-    const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&run_lib_unit_tests.step);
+    const mod_tests = b.addTest(.{ .root_module = mod });
+    const run_mod_tests = b.addRunArtifact(mod_tests);
+    const test_step = b.step("test", "Run tests");
+    test_step.dependOn(&run_mod_tests.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,23 +1,12 @@
 .{
-    .name = "zigdeck",
-    // This is a [Semantic Version](https://semver.org/).
-    // In a future version of Zig it will be used for package deduplication.
+    .name = .zigdeck,
     .version = "0.1.1",
-
-    // Specifies the set of files and directories that are included in this package.
-    // Only files and directories listed here are included in the `hash` that
-    // is computed for this package.
-    // Paths are relative to the build root. Use the empty string (`""`) to refer to
-    // the build root itself.
-    // A directory listed here means that all files within, recursively, are included.
+    .fingerprint = 0xbf754cff49b3eefd, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.15.2",
     .paths = .{
-        // This makes *all* files, recursively, included in this package. It is generally
-        // better to explicitly list the files and directories instead, to insure that
-        // fetching from tarballs, file system paths, and version control all result
-        // in the same contents hash.
-        "lib.zig",
         "build.zig",
         "build.zig.zon",
+        "lib.zig",
         "LICENSE",
         "README.md",
     },

--- a/lib.zig
+++ b/lib.zig
@@ -60,8 +60,8 @@ pub const Deck = struct {
     pub fn init() Deck {
         var deck: Deck = .{ .cards = undefined, .top = 0 };
         var i: usize = 0;
-        inline for (@typeInfo(Suit).Enum.fields) |suit| {
-            inline for (@typeInfo(Face).Enum.fields) |face| {
+        inline for (@typeInfo(Suit).@"enum".fields) |suit| {
+            inline for (@typeInfo(Face).@"enum".fields) |face| {
                 deck.cards[i] = Card{ .suit = @enumFromInt(suit.value), .face = @enumFromInt(face.value) };
                 i += 1;
             }
@@ -69,7 +69,7 @@ pub const Deck = struct {
         return deck;
     }
 
-    pub fn shuffle(deck: *Deck, rng: *const std.rand.Random) void {
+    pub fn shuffle(deck: *Deck, rng: *const std.Random) void {
         for (deck.cards, 0..) |_, item| {
             const i = item;
             const j = rng.int(usize) % deck.cards.len;
@@ -88,7 +88,7 @@ pub const Deck = struct {
 };
 
 test "Deck operations" {
-    var deck = Deck.init();
+    var deck: Deck = .init();
     try std.testing.expectEqual(Suit.Clubs, deck.cards[0].suit);
     try std.testing.expectEqual(Face.Ace, deck.cards[0].face);
     try std.testing.expectEqual(Suit.Clubs, deck.cards[1].suit);
@@ -100,10 +100,10 @@ test "Deck operations" {
     try std.testing.expectEqual(Suit.Spades, deck.cards[48].suit);
     try std.testing.expectEqual(Face.King, deck.cards[51].face);
 
-    // var rng = std.rand.DefaultPrng.init(@as(u64, @intCast(std.time.milliTimestamp())));
-    var rng = std.rand.DefaultPrng.init(1);
-    Deck.shuffle(&deck, &rng.random());
-    const card = Deck.getTopCard(&deck) orelse return;
+    // var rng: std.Random.DefaultPrng = .init(@as(u64, @intCast(std.time.milliTimestamp())));
+    var rng: std.Random.DefaultPrng = .init(1);
+    deck.shuffle(&rng.random());
+    const card = deck.getTopCard() orelse return;
     try std.testing.expectEqual(Suit.Clubs, card.suit);
     try std.testing.expectEqual(Face.Queen, card.face);
     std.debug.print("Top card: Suit = {}, Value = {}\n", .{ card.suit, card.face });


### PR DESCRIPTION
This incorporates stdlib changes made in the 0.14 and 0.15 releases.

I regenerated the build files from 0.15.2 `zig init`, which generates a fingerprint that can be used by this library for the new module system.

It appears that the static library generates correctly, but I don't know exactly how to use the static library in another program -- or why we should now that Zig modules exist and the package manager supports modules as dependencies. Maybe this artifact can be removed, leaving just the module?